### PR TITLE
Generalize PureModule + Scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ class Foo(nnx.Module):
 
 model = Foo(din=12, dout=2, ctx=nnx.context(0))
 ```
-As shown above, python container types such as `list`, `tuple`, and `dict` are treated as static attributes, if similar functionality is needed, NNX provides the `Sequence` and `Map` Modules.
+As shown above, python container types such as `list`, `tuple`, and `dict` are treated as static attributes, if similar functionality is needed, NNX provides the `Sequence` and `Dict` Modules.
 
 ### Functional API
 
@@ -264,6 +264,28 @@ params = state.filter("params")
 # get params and batch_stats
 params, batch_stats = state.filter("params", "batch_stats")
 ```
+
+### Filters
+
+Filters let you select subsets of nodes based on some criteria. These are use throughout the API in method like `partition`, `filter`, and `pop_state`. There are 4 types of filters:
+
+* `str`: matches all `Variable` nodes (e.g. `nnx.param` or `nnx.var`) with the given `collection` name.
+* `type`: matches all node instances of the given type.
+* `...`: matches all nodes.
+* `(path, any) -> bool`: a predicate function that takes a node path and value and returns a boolean.
+* `Tuple[Filter, ...]`: a tuple of filters, matches all nodes that match any of the filters.
+
+NNX also provides the following custom filters:
+
+* `nnx.Not(filter)`: matches all nodes that do not match the given filter
+* `nnx.buffers`: matches all `numpy.ndarray` and `jax.Array` nodes
+
+Here is an example of how to use `Not` and `buffers`:
+```python
+rest = module.filter(nnx.Not("params"))
+buffers = module.filter(nnx.buffers)
+```
+
 
 ### Capturing Intermediate Values
 In NNX you can easily propagate intemediate values by simply assigning them to an attribute at runtime. For convenience, you should assign them to a `Variable` attribute with a `collection` name by using `nnx.var` so you can easily retrieve them later.

--- a/README.md
+++ b/README.md
@@ -63,40 +63,9 @@ assert model.count == 1
 In this example `nnx.context(0)` create a `PRNGKey` for `params` with seed `0`, this is used by `make_rng`
 inside `__init__` to generate a random key to initialize the parameters.
 
-### Training
+#### Training with the Functional API
 
-Here we show case two different approaches to training the model defined in the previous secition. The first one uses lifted transforms and the second one uses the functional API. Both approaches are equivalent and produce the same results.
-
-<details><summary>Lifted Transforms</summary>
-
-In this example, we uset the `nnx.jit` and `nnx.grad` lifted transforms to define the training step. The model is trained using Stochastic Gradient Descent (SGD) and `train_step` doesn't require a return statement in this case as the model's state is automatically updated.
-
-```python
-@nnx.jit
-def train_step(model, x, y):
-    def loss_fn(model):
-        y_pred = model(x)
-        return jax.numpy.mean((y_pred - y) ** 2)
-    
-    # compute gradient
-    grads: nnx.State = nnx.grad(loss_fn, wrt="params")(model)
-    # SGD update
-    model.update_state(
-        jax.tree_map(lambda w, g: w - 0.1 * g, model.filter("params"), grads)
-    )
-
-# execute the training step
-train_step(model, x, y)
-assert model.count == 2
-```
-
-**Note**: Using `nnx.jit` can introduce some overhead when compared to using `jax.jit` directly. Use `nnx.jit` for simple prototypes and getting started quickly. For more advanced use cases, use the functional API.
-
-</details>
-
-<details><summary>Functional API </summary>
-
-In this example, we utilize the functional API for training. This approach provides more control over the state and allows you to use regular JAX transformations. The model is also trained using Stochastic Gradient Descent (SGD).
+The [Functional API](#functional-api) converts an NNX Module python semantics into pure pytree object with functional semantics. It is the recommended way to use NNX as it provides tight control over the state, allows you to use regular JAX transformations, and it minimizes overhead. In this example the model will be trained using Stochastic Gradient Descent (SGD).
 
 ```python
 (params, counts), moduledef = model.partition("params", "counts")
@@ -121,7 +90,30 @@ model = moduledef.merge(params, counts)
 assert model.count == 2
 ```
 
-</details>
+#### Training with Lifted Transforms
+
+[Lifted Transforms](#lifted-transforms) provide a convenient way interact with NNX Modules. In this example, we use the `nnx.jit` and `nnx.grad` lifted transforms to define the training step. The model is trained using Stochastic Gradient Descent (SGD). Because lifted transforms automatically update the Module's state, `train_step` doesn't require a return statement.
+
+```python
+@nnx.jit
+def train_step(model, x, y):
+    def loss_fn(model):
+        y_pred = model(x)
+        return jax.numpy.mean((y_pred - y) ** 2)
+    
+    # compute gradient
+    grads: nnx.State = nnx.grad(loss_fn, wrt="params")(model)
+    # SGD update
+    model.update_state(
+        jax.tree_map(lambda w, g: w - 0.1 * g, model.filter("params"), grads)
+    )
+
+# execute the training step
+train_step(model, x, y)
+assert model.count == 2
+```
+
+**Note**: Using `nnx.jit` introduces some overhead when compared to using `jax.jit` directly. Use `nnx.jit` for simple prototypes, but for production code use `jax.jit` directly.
 
 ## Examples
 
@@ -336,7 +328,7 @@ Alternatively, you can use `State.filter` to retrieve the `intermediates` nodes 
 
 
 
-### Stateful Transforms
+### Lifted Transforms
 
 Stateful transforms take a Module as their first argument, track changes in the state that occur within the transformation, and automatically propagate those changes to the input Module outside the transformation. In general, they behave as stateful functions with respect to the first argument.
 

--- a/examples/04_pure.py
+++ b/examples/04_pure.py
@@ -61,7 +61,7 @@ def train_step(pure_model: nnx.PureModule[MLP], batch):
 
 
 @jax.jit
-def test_step(pure_model: nnx.PureModule[MLP], batch):
+def test_step(pure_model: nnx.Pure[MLP], batch):
     x, y = batch
     y_pred = pure_model.call(x)
     loss = jnp.mean((y - y_pred) ** 2)

--- a/examples/04_pure.py
+++ b/examples/04_pure.py
@@ -61,7 +61,7 @@ def train_step(pure_model: nnx.PureModule[MLP], batch):
 
 
 @jax.jit
-def test_step(pure_model: nnx.Pure[MLP], batch):
+def test_step(pure_model: nnx.PureModule[MLP], batch):
     x, y = batch
     y_pred = pure_model.call(x)
     loss = jnp.mean((y - y_pred) ** 2)

--- a/examples/09_parameter_surgery.py
+++ b/examples/09_parameter_surgery.py
@@ -1,0 +1,42 @@
+from typing import Callable
+
+import jax
+
+import nnx
+
+
+# lets pretend this function loads a pretrained model from a checkpoint
+def load_backbone():
+    return nnx.Linear(784, 128, ctx=nnx.context(0))
+
+
+# create a simple linear classifier using a pretrained backbone
+class Classifier(nnx.Module):
+    def __init__(self, backbone: Callable[[jax.Array], jax.Array], *, ctx: nnx.Context):
+        self.backbone = backbone
+        self.head = nnx.Linear(128, 10, ctx=ctx)
+
+    def __call__(self, x):
+        x = self.backbone(x)
+        x = nnx.relu(x)
+        x = self.head(x)
+        return x
+
+
+# load the backbone
+backbone = load_backbone()
+
+# create the classifier using the pretrained backbone, here we are doing
+# "parameter surgery", however, compared to Flax where you must manually
+# construct the parameter structure, in NNX this is done automatically
+model = Classifier(backbone, ctx=nnx.context(42))
+
+# create a filter to select all the parameters that are not part of the
+# backbone, i.e. the classifier parameters
+is_trainable = nnx.All(lambda path, x: path[0] != "backbone", "params")
+
+# partition the parameters into trainable and non-trainable parameters
+(trainable_params, rest), moduledef = model.partition(is_trainable, ...)
+
+print("trainable_params =", jax.tree_map(jax.numpy.shape, trainable_params))
+print("rest = ", jax.tree_map(jax.numpy.shape, rest))

--- a/examples/09_parameter_surgery.py
+++ b/examples/09_parameter_surgery.py
@@ -23,17 +23,16 @@ class Classifier(nnx.Module):
         return x
 
 
-# load the backbone
 backbone = load_backbone()
 
-# create the classifier using the pretrained backbone, here we are doing
-# "parameter surgery", however, compared to Flax where you must manually
+# create the classifier using the pretrained backbone, here we are technically
+# doing "parameter surgery", however, compared to Haiku/Flax where you must manually
 # construct the parameter structure, in NNX this is done automatically
 model = Classifier(backbone, ctx=nnx.context(42))
 
 # create a filter to select all the parameters that are not part of the
 # backbone, i.e. the classifier parameters
-is_trainable = nnx.All(lambda path, x: path[0] != "backbone", "params")
+is_trainable = nnx.All("params", lambda path, node: path[0] != "backbone")
 
 # partition the parameters into trainable and non-trainable parameters
 (trainable_params, rest), moduledef = model.partition(is_trainable, ...)

--- a/nnx/__init__.py
+++ b/nnx/__init__.py
@@ -24,7 +24,7 @@ from .dataclasses import (
     var_field,
 )
 from .errors import TraceContextError
-from .helpers import Map, Sequence, TrainState
+from .helpers import Dict, Sequence, TrainState
 from .module import Module, ModuleDef, PureModule
 from .nn import initializers
 from .nn.activations import (
@@ -58,7 +58,7 @@ from .nn.linear import Conv, Embed, Linear
 from .nn.normalization import BatchNorm, LayerNorm
 from .nn.stochastic import Dropout
 from .nodes import is_node, register_node_type
-from .partitioning import buffers
+from .partitioning import Not, buffers
 from .pytreelib import Pytree
 from .state import State
 from .transforms import grad, jit

--- a/nnx/__init__.py
+++ b/nnx/__init__.py
@@ -61,4 +61,4 @@ from .nodes import is_node, register_node_type
 from .partitioning import All, Not, buffers
 from .pytreelib import Pytree
 from .state import State
-from .transforms import grad, jit
+from .transforms import grad, jit, scan

--- a/nnx/__init__.py
+++ b/nnx/__init__.py
@@ -25,7 +25,7 @@ from .dataclasses import (
 )
 from .errors import TraceContextError
 from .helpers import Dict, Sequence, TrainState
-from .module import Module, ModuleDef, PureModule
+from .module import Module, ModuleDef, Pure, PureModule
 from .nn import initializers
 from .nn.activations import (
     celu,

--- a/nnx/__init__.py
+++ b/nnx/__init__.py
@@ -58,7 +58,7 @@ from .nn.linear import Conv, Embed, Linear
 from .nn.normalization import BatchNorm, LayerNorm
 from .nn.stochastic import Dropout
 from .nodes import is_node, register_node_type
-from .partitioning import Not, buffers
+from .partitioning import All, Not, buffers
 from .pytreelib import Pytree
 from .state import State
 from .transforms import grad, jit

--- a/nnx/helpers.py
+++ b/nnx/helpers.py
@@ -4,7 +4,7 @@ import optax
 
 from nnx import containers, pytreelib, utils
 from nnx.contextlib import Context
-from nnx.module import ApplyCaller, Module, PureModule
+from nnx.module import ApplyCaller, Module, Pure
 from nnx.state import State
 
 A = tp.TypeVar("A")
@@ -87,7 +87,7 @@ class Sequence(Module, tp.Generic[A]):
 
 
 class ModuleDefApply(tp.Protocol, tp.Generic[M]):
-    def __call__(self, state: State, *states: State) -> ApplyCaller["PureModule[M]"]:
+    def __call__(self, state: State, *states: State) -> ApplyCaller["Pure[M]"]:
         ...
 
 

--- a/nnx/helpers.py
+++ b/nnx/helpers.py
@@ -11,7 +11,7 @@ A = tp.TypeVar("A")
 M = tp.TypeVar("M", bound=Module)
 
 
-class Map(Module, tp.Mapping[str, A]):
+class Dict(Module, tp.Mapping[str, A]):
     @tp.overload
     def __init__(self, __iterable: tp.Iterable[tp.Tuple[str, A]]):
         ...

--- a/nnx/module.py
+++ b/nnx/module.py
@@ -345,9 +345,9 @@ class ModuleMeta(ABCMeta):
     if not tp.TYPE_CHECKING:
 
         def __call__(self, *args: Any, **kwargs: Any) -> Any:
-            return self.call(*args, **kwargs)
+            return self._meta_call(*args, **kwargs)
 
-    def call(self: tp.Type[M], *args, **kwargs) -> M:
+    def _meta_call(self: tp.Type[M], *args, **kwargs) -> M:
         module = self.__new__(self, *args, **kwargs)
         vars(module)["_module__state"] = ModuleState(tracers.TraceState())
         module.__init__(*args, **kwargs)

--- a/nnx/module.py
+++ b/nnx/module.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import jax.tree_util as jtu
 
-from nnx import errors, nodes, partitioning, reprlib, tracers
+from nnx import errors, nodes, partitioning, reprlib, tracers, utils
 from nnx.containers import Container, Sharding, Variable
 from nnx.state import State
 
@@ -103,7 +103,7 @@ class ModuleDef(tp.Generic[M], reprlib.Representable):
         return module
 
     def apply(self, state: State, *states: State) -> ApplyCaller["Pure[State, M]"]:
-        accessesor = DelayedAccessor()
+        accessesor = utils.DelayedAccessor()
 
         def _context(accessesor, *args, **kwargs) -> tp.Tuple[tp.Any, Pure[State, M]]:
             module = self.merge(state, *states)
@@ -111,7 +111,7 @@ class ModuleDef(tp.Generic[M], reprlib.Representable):
             out = fn(*args, **kwargs)
             return out, module.partition()
 
-        return CallableProxy(_context, accessesor)  # type: ignore
+        return utils.CallableProxy(_context, accessesor)  # type: ignore
 
 
 def _moddef_flatten(moduledef: ModuleDef[M]):
@@ -166,14 +166,14 @@ class Pure(tp.Tuple[S, ModuleDef[M]]):
 
     @property
     def call(self) -> M:
-        accessesor = DelayedAccessor()
+        accessesor = utils.DelayedAccessor()
 
         def _context(accessesor, *args, **kwargs):
             module = self.merge()
             fn = accessesor(module)
             return fn(*args, **kwargs)
 
-        return CallableProxy(_context, accessesor)  # type: ignore
+        return utils.CallableProxy(_context, accessesor)  # type: ignore
 
     def get_state(self) -> State:
         if isinstance(self.states, tuple):
@@ -321,44 +321,6 @@ def _pure_module_unflatten(_, values: tp.Tuple[S, ModuleDef[M]]):
 jtu.register_pytree_node(Pure, _pure_module_flatten, _pure_module_unflatten)
 
 PureModule = Pure[tp.Union[State, tp.Tuple[State, ...]], M]
-
-
-class _ProxyContext(tp.Protocol):
-    def __call__(self, __fn: tp.Callable[..., tp.Any], *args, **kwargs) -> tp.Any:
-        ...
-
-
-@dataclasses.dataclass
-class CallableProxy:
-    _proxy_context: _ProxyContext
-    _proxy_callable: tp.Callable[..., tp.Any]
-
-    def __call__(self, *args, **kwargs):
-        return self._proxy_context(self._proxy_callable, *args, **kwargs)
-
-    def __getattr__(self, name) -> "CallableProxy":
-        return CallableProxy(self._proxy_context, getattr(self._proxy_callable, name))
-
-    def __getitem__(self, key) -> "CallableProxy":
-        return CallableProxy(self._proxy_context, self._proxy_callable[key])
-
-
-def _identity(x):
-    return x
-
-
-@dataclasses.dataclass
-class DelayedAccessor:
-    accessor: tp.Callable[[tp.Any], tp.Any] = _identity
-
-    def __call__(self, x):
-        return self.accessor(x)
-
-    def __getattr__(self, name):
-        return DelayedAccessor(lambda x: getattr(x, name))
-
-    def __getitem__(self, key):
-        return DelayedAccessor(lambda x: x[key])
 
 
 SEEN_MODULES_REPR: tp.Set[int] = set()
@@ -557,7 +519,7 @@ class Module(reprlib.Representable, metaclass=ModuleMeta):
 
     @property
     def apply(self: M) -> ApplyCaller[M]:
-        accessesor = DelayedAccessor()
+        accessesor = utils.DelayedAccessor()
 
         def _context(accessesor, *args, **kwargs) -> tp.Tuple[tp.Any, M]:
             module = self.clone()
@@ -565,7 +527,7 @@ class Module(reprlib.Representable, metaclass=ModuleMeta):
             out = fn(*args, **kwargs)
             return out, module
 
-        return CallableProxy(_context, accessesor)  # type: ignore
+        return utils.CallableProxy(_context, accessesor)  # type: ignore
 
     def update_state(
         self: M,

--- a/nnx/module.py
+++ b/nnx/module.py
@@ -177,7 +177,7 @@ class PureModule(tp.Tuple[State, ModuleDef[M]]):
     @tp.overload
     def filter(
         self,
-        filter: partitioning.CollectionFilter,
+        filter: partitioning.Filter,
         /,
     ) -> State:
         ...
@@ -185,35 +185,35 @@ class PureModule(tp.Tuple[State, ModuleDef[M]]):
     @tp.overload
     def filter(
         self,
-        filter: partitioning.CollectionFilter,
-        filter2: partitioning.CollectionFilter,
+        filter: partitioning.Filter,
+        filter2: partitioning.Filter,
         /,
-        *filters: partitioning.CollectionFilter,
+        *filters: partitioning.Filter,
     ) -> tp.Tuple[State, ...]:
         ...
 
     def filter(
-        self, *filters: partitioning.CollectionFilter
+        self, *filters: partitioning.Filter
     ) -> tp.Union[State, tp.Tuple[State, ...]]:
         return self.state.filter(*filters)
 
     @tp.overload
-    def partition(self, first: partitioning.CollectionFilter, /) -> "PureModule[M]":
+    def partition(self, first: partitioning.Filter, /) -> "PureModule[M]":
         ...
 
     @tp.overload
     def partition(
         self,
-        first: partitioning.CollectionFilter,
-        second: partitioning.CollectionFilter,
+        first: partitioning.Filter,
+        second: partitioning.Filter,
         /,
-        *filters: partitioning.CollectionFilter,
+        *filters: partitioning.Filter,
     ) -> tp.Tuple[tp.Tuple[State, ...], ModuleDef[M]]:
         ...
 
     def partition(
         self,
-        *filters: partitioning.CollectionFilter,
+        *filters: partitioning.Filter,
     ) -> tp.Union["PureModule[M]", tp.Tuple[tp.Tuple[State, ...], ModuleDef[M]],]:
         states = self.state.partition(*filters)
         if isinstance(states, State):
@@ -223,22 +223,22 @@ class PureModule(tp.Tuple[State, ModuleDef[M]]):
 
     @tp.overload
     def pop_state(
-        self, filter: partitioning.CollectionFilter, /
+        self, filter: partitioning.Filter, /
     ) -> tp.Tuple[State, "PureModule[M]"]:
         ...
 
     @tp.overload
     def pop_state(
         self,
-        filter: partitioning.CollectionFilter,
-        filter2: partitioning.CollectionFilter,
+        filter: partitioning.Filter,
+        filter2: partitioning.Filter,
         /,
-        *filters: partitioning.CollectionFilter,
+        *filters: partitioning.Filter,
     ) -> tp.Tuple[tp.Tuple[State, ...], "PureModule[M]"]:
         ...
 
     def pop_state(
-        self, *filters: partitioning.CollectionFilter
+        self, *filters: partitioning.Filter
     ) -> tp.Tuple[tp.Union[State, tp.Tuple[State, ...]], "PureModule[M]"]:
         if len(filters) == 0:
             raise ValueError("At least one filter must be provided")
@@ -423,22 +423,22 @@ class Module(reprlib.Representable, metaclass=ModuleMeta):
         ...
 
     @tp.overload
-    def partition(self: M, first: partitioning.CollectionFilter, /) -> PureModule[M]:
+    def partition(self: M, first: partitioning.Filter, /) -> PureModule[M]:
         ...
 
     @tp.overload
     def partition(
         self: M,
-        first: partitioning.CollectionFilter,
-        second: partitioning.CollectionFilter,
+        first: partitioning.Filter,
+        second: partitioning.Filter,
         /,
-        *filters: partitioning.CollectionFilter,
+        *filters: partitioning.Filter,
     ) -> tp.Tuple[tp.Tuple[State, ...], ModuleDef[M]]:
         ...
 
     def partition(
         self: M,
-        *filters: partitioning.CollectionFilter,
+        *filters: partitioning.Filter,
     ) -> tp.Union[PureModule[M], tp.Tuple[tp.Tuple[State, ...], ModuleDef[M]]]:
         moduledef = _get_module_def(self)
         state = _get_module_state(self)
@@ -459,24 +459,24 @@ class Module(reprlib.Representable, metaclass=ModuleMeta):
         return _get_module_state(self)
 
     @tp.overload
-    def filter(self, first: partitioning.CollectionFilter, /) -> State:
+    def filter(self, first: partitioning.Filter, /) -> State:
         ...
 
     @tp.overload
     def filter(
         self,
-        first: partitioning.CollectionFilter,
-        second: partitioning.CollectionFilter,
+        first: partitioning.Filter,
+        second: partitioning.Filter,
         /,
-        *filters: partitioning.CollectionFilter,
+        *filters: partitioning.Filter,
     ) -> tp.Tuple[State, ...]:
         ...
 
     def filter(
         self,
-        first: partitioning.CollectionFilter,
+        first: partitioning.Filter,
         /,
-        *filters: partitioning.CollectionFilter,
+        *filters: partitioning.Filter,
     ) -> tp.Union[State, tp.Tuple[State, ...]]:
         state = _get_module_state(self)
 
@@ -490,7 +490,7 @@ class Module(reprlib.Representable, metaclass=ModuleMeta):
     @tp.overload
     def pop_state(
         self,
-        filter: partitioning.CollectionFilter,
+        filter: partitioning.Filter,
         /,
     ) -> State:
         ...
@@ -498,15 +498,15 @@ class Module(reprlib.Representable, metaclass=ModuleMeta):
     @tp.overload
     def pop_state(
         self,
-        filter: partitioning.CollectionFilter,
-        filter2: partitioning.CollectionFilter,
+        filter: partitioning.Filter,
+        filter2: partitioning.Filter,
         /,
-        *filters: partitioning.CollectionFilter,
+        *filters: partitioning.Filter,
     ) -> tp.Tuple[State, ...]:
         ...
 
     def pop_state(
-        self, *filters: partitioning.CollectionFilter
+        self, *filters: partitioning.Filter
     ) -> tp.Union[State, tp.Tuple[State, ...]]:
         if len(filters) == 0:
             raise ValueError("Expected at least one filter")
@@ -751,7 +751,7 @@ def _build_module_recursive(
 
 def _pop(
     module: Module,
-    filters: tp.Tuple[partitioning.CollectionFilter, ...],
+    filters: tp.Tuple[partitioning.Filter, ...],
 ) -> tp.Tuple[State, ...]:
     module_index: tp.Dict[int, int] = {}
     path: Path = ()

--- a/nnx/partitioning.py
+++ b/nnx/partitioning.py
@@ -14,7 +14,7 @@ else:
 
 Path = tp.Tuple[str, ...]
 Predicate = tp.Callable[[Path, tp.Any], bool]
-FilterLiteral = tp.Union[str, type, Predicate, ellipsis]
+FilterLiteral = tp.Union[str, type, Predicate, ellipsis, None]
 Filter = tp.Union[FilterLiteral, tp.Tuple[FilterLiteral, ...]]
 
 
@@ -25,6 +25,8 @@ def to_predicate(filter: Filter) -> Predicate:
         return OfType(filter)
     elif filter is Ellipsis:
         return Everything()
+    elif filter is None:
+        return Nothing()
     elif callable(filter):
         return filter
     elif isinstance(filter, tp.Tuple):
@@ -82,6 +84,11 @@ class Not:
 class Everything:
     def __call__(self, path: Path, x: tp.Any):
         return True
+
+
+class Nothing:
+    def __call__(self, path: Path, x: tp.Any):
+        return False
 
 
 buffers = (jax.Array, np.ndarray)

--- a/nnx/partitioning.py
+++ b/nnx/partitioning.py
@@ -28,7 +28,7 @@ def to_predicate(filter: Filter) -> Predicate:
     elif callable(filter):
         return filter
     elif isinstance(filter, tp.Tuple):
-        return Any(filter)
+        return Any(*filter)
     else:
         raise TypeError(f"Invalid collection filter: {filter}")
 
@@ -52,13 +52,23 @@ class OfType:
 
 
 class Any:
-    def __init__(self, collection_filters: tp.Sequence[Filter]):
+    def __init__(self, *filters: Filter):
         self.predicates = tuple(
-            to_predicate(collection_filter) for collection_filter in collection_filters
+            to_predicate(collection_filter) for collection_filter in filters
         )
 
     def __call__(self, path: Path, x: tp.Any):
         return any(predicate(path, x) for predicate in self.predicates)
+
+
+class All:
+    def __init__(self, *filters: Filter):
+        self.predicates = tuple(
+            to_predicate(collection_filter) for collection_filter in filters
+        )
+
+    def __call__(self, path: Path, x: tp.Any):
+        return all(predicate(path, x) for predicate in self.predicates)
 
 
 class Not:

--- a/nnx/state.py
+++ b/nnx/state.py
@@ -52,24 +52,24 @@ class State(tp.Mapping[tp.Tuple[str, ...], Leaf], reprlib.Representable):
             yield reprlib.Attr(str(k), v)
 
     @tp.overload
-    def partition(self, first: partitioning.CollectionFilter, /) -> "State":
+    def partition(self, first: partitioning.Filter, /) -> "State":
         ...
 
     @tp.overload
     def partition(
         self,
-        first: partitioning.CollectionFilter,
-        second: partitioning.CollectionFilter,
+        first: partitioning.Filter,
+        second: partitioning.Filter,
         /,
-        *filters: partitioning.CollectionFilter,
+        *filters: partitioning.Filter,
     ) -> tp.Tuple["State", ...]:
         ...
 
     def partition(
         self,
-        first: partitioning.CollectionFilter,
+        first: partitioning.Filter,
         /,
-        *filters: partitioning.CollectionFilter,
+        *filters: partitioning.Filter,
     ) -> tp.Union["State", tp.Tuple["State", ...]]:
         *states, rest = _split_state(self, first, *filters)
 
@@ -88,7 +88,7 @@ class State(tp.Mapping[tp.Tuple[str, ...], Leaf], reprlib.Representable):
     @tp.overload
     def filter(
         self,
-        first: partitioning.CollectionFilter,
+        first: partitioning.Filter,
         /,
     ) -> "State":
         ...
@@ -96,18 +96,18 @@ class State(tp.Mapping[tp.Tuple[str, ...], Leaf], reprlib.Representable):
     @tp.overload
     def filter(
         self,
-        first: partitioning.CollectionFilter,
-        second: partitioning.CollectionFilter,
+        first: partitioning.Filter,
+        second: partitioning.Filter,
         /,
-        *filters: partitioning.CollectionFilter,
+        *filters: partitioning.Filter,
     ) -> tp.Tuple["State", ...]:
         ...
 
     def filter(
         self,
-        first: partitioning.CollectionFilter,
+        first: partitioning.Filter,
         /,
-        *filters: partitioning.CollectionFilter,
+        *filters: partitioning.Filter,
     ) -> tp.Union["State", tp.Tuple["State", ...]]:
         (*states, _rest) = _split_state(self, first, *filters)
 
@@ -173,7 +173,7 @@ jax.tree_util.register_pytree_with_keys(
 
 def _split_state(
     state: StateMapping,
-    *filters: partitioning.CollectionFilter,
+    *filters: partitioning.Filter,
 ) -> tp.Tuple[StateDict, ...]:
     predicates = tuple(map(partitioning.to_predicate, filters))
 

--- a/nnx/transforms.py
+++ b/nnx/transforms.py
@@ -242,11 +242,6 @@ def grad(
     return ref_grad
 
 
-import flax.linen
-
-flax.linen.scan
-
-
 # NOTE: I don't understand why variable_broadcasts exists. Passing them as
 # captures to `scan_fn` makes it impossible to propagate state updates from
 # them. Maybe, there should only be `variable_carry` and `variable_axes`.

--- a/nnx/transforms.py
+++ b/nnx/transforms.py
@@ -189,7 +189,7 @@ class GradTransform:
 @tp.overload
 def grad(
     fun: tp.Callable[..., tp.Any],
-    wrt: partitioning.CollectionFilter = "params",
+    wrt: partitioning.Filter = "params",
     *,
     stateful: bool = True,
     holomorphic: bool = False,
@@ -202,7 +202,7 @@ def grad(
 @tp.overload
 def grad(
     fun: tp.Callable[..., tp.Any],
-    wrt: partitioning.CollectionFilter = "params",
+    wrt: partitioning.Filter = "params",
     *,
     stateful: bool = True,
     has_aux: tp.Literal[True],
@@ -215,7 +215,7 @@ def grad(
 
 def grad(
     fun: tp.Callable[..., tp.Any],
-    wrt: partitioning.CollectionFilter = "params",
+    wrt: partitioning.Filter = "params",
     *,
     stateful: bool = True,
     has_aux: bool = False,

--- a/nnx/transforms.py
+++ b/nnx/transforms.py
@@ -286,6 +286,9 @@ class Scan(Module, tp.Generic[M]):
     def create_module(
         self: "Scan[M]", *args, ctx: tp.Optional[contextlib.Context] = None, **kwargs
     ) -> M:
+        if self.variable_axes and self.length is None:
+            raise ValueError("Cannot use variable_axes without specifying a length")
+
         key_values = []
 
         if ctx is not None:
@@ -526,8 +529,7 @@ def scan(
     variable_axes: tp.Mapping[partitioning.Filter, int] = MappingProxyType({}),
     variable_broadcast: partitioning.Filter = None,
     variable_carry: partitioning.Filter = ...,
-    init_split_rngs: contextlib.RngFilter = None,
-    call_split_rngs: contextlib.RngFilter = None,
+    split_rngs: contextlib.RngFilter = None,
     in_axes=0,
     out_axes=0,
     length: tp.Optional[int] = None,
@@ -544,8 +546,7 @@ def scan(
             variable_axes=variable_axes,
             variable_broadcast=variable_broadcast,
             variable_carry=variable_carry,
-            split_rngs=init_split_rngs,
-            call_split_rngs=call_split_rngs,
+            split_rngs=split_rngs,
             in_axes=in_axes,
             out_axes=out_axes,
             length=length,

--- a/nnx/utils.py
+++ b/nnx/utils.py
@@ -1,3 +1,4 @@
+import dataclasses
 import inspect
 import typing as tp
 
@@ -19,3 +20,41 @@ def has_keyword_arg(func: tp.Callable[..., tp.Any], name: str) -> bool:
         and param.kind in (param.KEYWORD_ONLY, param.POSITIONAL_OR_KEYWORD)
         for param in inspect.signature(func).parameters.values()
     )
+
+
+class _ProxyContext(tp.Protocol):
+    def __call__(self, __fn: tp.Callable[..., tp.Any], *args, **kwargs) -> tp.Any:
+        ...
+
+
+@dataclasses.dataclass
+class CallableProxy:
+    _proxy_context: _ProxyContext
+    _proxy_callable: tp.Callable[..., tp.Any]
+
+    def __call__(self, *args, **kwargs):
+        return self._proxy_context(self._proxy_callable, *args, **kwargs)
+
+    def __getattr__(self, name) -> "CallableProxy":
+        return CallableProxy(self._proxy_context, getattr(self._proxy_callable, name))
+
+    def __getitem__(self, key) -> "CallableProxy":
+        return CallableProxy(self._proxy_context, self._proxy_callable[key])
+
+
+def _identity(x):
+    return x
+
+
+@dataclasses.dataclass
+class DelayedAccessor:
+    accessor: tp.Callable[[tp.Any], tp.Any] = _identity
+
+    def __call__(self, x):
+        return self.accessor(x)
+
+    def __getattr__(self, name):
+        return DelayedAccessor(lambda x: getattr(x, name))
+
+    def __getitem__(self, key):
+        return DelayedAccessor(lambda x: x[key])

--- a/nnx/utils.py
+++ b/nnx/utils.py
@@ -2,6 +2,9 @@ import dataclasses
 import inspect
 import typing as tp
 
+import jax
+import jax.tree_util as jtu
+
 A = tp.TypeVar("A")
 
 
@@ -58,3 +61,15 @@ class DelayedAccessor:
 
     def __getitem__(self, key):
         return DelayedAccessor(lambda x: x[key])
+
+
+def tree_map_upto_left(
+    f: tp.Callable[[tp.Any, tp.Any], tp.Any], left: tp.Any, right: tp.Any
+) -> tp.Any:
+    leaves_left, treedef = jtu.tree_flatten(left)
+    leaves_right = treedef.flatten_up_to(right)
+
+    return treedef.unflatten(
+        f(left_leaf, right_leaf)
+        for left_leaf, right_leaf in zip(leaves_left, leaves_right)
+    )

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -6,7 +6,7 @@ import nnx
 
 class TestHelpers:
     def test_train_state(self):
-        m = nnx.Map(a=nnx.param(1), b=nnx.var("batch_stats", 2))
+        m = nnx.Dict(a=nnx.param(1), b=nnx.var("batch_stats", 2))
 
         (params, batch_stats), moduledef = m.partition("params", "batch_stats")
 

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -17,7 +17,7 @@ class TestModule:
         assert hasattr(foo, "_module__state")
 
     def test_trace_level(self):
-        m = nnx.Map(a=nnx.param(1))
+        m = nnx.Dict(a=nnx.param(1))
 
         @jax.jit
         def f():
@@ -30,10 +30,10 @@ class TestModule:
         f()
 
     def test_split_merge(self):
-        m = nnx.Map(a=nnx.param(1))
+        m = nnx.Dict(a=nnx.param(1))
 
         @jax.jit
-        def g(pure_module: nnx.PureModule[nnx.Map[int]]):
+        def g(pure_module: nnx.PureModule[nnx.Dict[int]]):
             m = pure_module.merge()
             m.a = 2
             return m.partition()
@@ -45,7 +45,7 @@ class TestModule:
     def test_no_trace_level_error_on_grad(self):
         # No trace level error occurs because jax doesn't update
         # its top trace for grad.
-        m = nnx.Map(a=nnx.param(1.0))
+        m = nnx.Dict(a=nnx.param(1.0))
 
         @jax.grad
         def f(_):
@@ -57,7 +57,7 @@ class TestModule:
     def test_trace_level_error_on_nnx_grad(self):
         # error occurs because nnx updates its nnx_trace
         # in nnx.grad.
-        m = nnx.Map(a=nnx.param(1.0))
+        m = nnx.Dict(a=nnx.param(1.0))
 
         @nnx.grad
         def f(_):
@@ -88,8 +88,8 @@ class TestModule:
         assert isinstance(y, jax.Array)
 
     def test_shared_module(self):
-        m1 = nnx.Map(a=nnx.param(1), b=nnx.param(2))
-        m2 = nnx.Map(x=m1, y=m1, z=nnx.param(3))
+        m1 = nnx.Dict(a=nnx.param(1), b=nnx.param(2))
+        m2 = nnx.Dict(x=m1, y=m1, z=nnx.param(3))
 
         m3 = m2.partition().merge()
 
@@ -115,10 +115,10 @@ class TestModule:
         r1 = nnx.Variable(1, "", None)
         r2 = nnx.Variable(2, "", None)
 
-        m = m0 = nnx.Map({"a": nnx.Sequence([r1, r2]), "b": r1})
+        m = m0 = nnx.Dict({"a": nnx.Sequence([r1, r2]), "b": r1})
 
         @jax.jit
-        def f(pure_module: nnx.PureModule[nnx.Map[Any]]):
+        def f(pure_module: nnx.PureModule[nnx.Dict[Any]]):
             m = pure_module.merge()
 
             assert m["a"][0] is not m["b"]
@@ -137,10 +137,10 @@ class TestModule:
         assert m["b"] is not m0["b"]
 
     def test_cross_barrier(self):
-        m = nnx.Map(a=nnx.param(1))
+        m = nnx.Dict(a=nnx.param(1))
 
         @jax.jit
-        def g(pure_module: nnx.PureModule[nnx.Map[int]]):
+        def g(pure_module: nnx.PureModule[nnx.Dict[int]]):
             m = pure_module.merge()
             m.a += 1
             return m.partition()
@@ -152,7 +152,7 @@ class TestModule:
 
     def test_no_rejit(self):
         n = 0
-        m = nnx.Map(a=nnx.param(1))
+        m = nnx.Dict(a=nnx.param(1))
 
         @jax.jit
         def g(pure_module):
@@ -184,10 +184,10 @@ class TestModule:
         r1 = nnx.Variable(1, "", None)
         r2 = nnx.Variable(2, "", None)
         v1 = 3
-        m = nnx.Map(
+        m = nnx.Dict(
             {
                 "a": nnx.Sequence([r1, r2, v1]),
-                "b": nnx.Map({"c": r1, "d": r2}),
+                "b": nnx.Dict({"c": r1, "d": r2}),
             }
         )
 
@@ -200,10 +200,10 @@ class TestModule:
         r1 = nnx.Variable(1, "", None)
         r2 = nnx.Variable(2, "", None)
         v1 = jax.numpy.array(3)
-        m = nnx.Map(
+        m = nnx.Dict(
             {
                 "a": nnx.Sequence([r1, r2, v1]),
-                "b": nnx.Map({"c": r1, "d": r2}),
+                "b": nnx.Dict({"c": r1, "d": r2}),
             }
         )
 
@@ -212,9 +212,9 @@ class TestModule:
         assert len(jax.tree_util.tree_leaves(p)) == 5
 
     def test_clone(self):
-        m = nnx.Map(
+        m = nnx.Dict(
             a=nnx.Sequence([nnx.param(1), nnx.param(2), 3]),
-            b=nnx.Map(c=nnx.param(1), d=nnx.param(2)),
+            b=nnx.Dict(c=nnx.param(1), d=nnx.param(2)),
         )
 
         m2 = m.clone()

--- a/tests/test_partitioning.py
+++ b/tests/test_partitioning.py
@@ -15,7 +15,7 @@ def has_collection(collection):
 
 class TestPartitioning:
     def test_partition_tree(self):
-        m = nnx.Map(
+        m = nnx.Dict(
             a=nnx.Sequence([nnx.param(1), nnx.var("batch_stats", 2)]),
             b=nnx.param(2),
             c=100,
@@ -41,7 +41,7 @@ class TestPartitioning:
         assert m2.c == 100
 
     def test_update_from(self):
-        m = nnx.Map(
+        m = nnx.Dict(
             a=nnx.Sequence([nnx.param(1), nnx.var("batch_stats", 3)]),
             b=nnx.param(2),
             c=100,
@@ -58,7 +58,7 @@ class TestPartitioning:
         assert m.c == 100
 
     def test_update_from_with_array_leaf(self):
-        m = nnx.Map(
+        m = nnx.Dict(
             a=nnx.Sequence([nnx.param(1), nnx.var("batch_stats", 3)]),
             b=nnx.param(2),
             c=jax.numpy.array(100),
@@ -75,7 +75,7 @@ class TestPartitioning:
         assert m.c == 200
 
     def test_grad_example(self):
-        m = nnx.Map(
+        m = nnx.Dict(
             a=nnx.Sequence([nnx.param(1.0), nnx.var("batch_stats", -10)]),
             b=nnx.param(2.0),
             c=100,
@@ -95,7 +95,7 @@ class TestPartitioning:
         assert m.c == 100
 
     def test_get_paritition(self):
-        m = nnx.Map(
+        m = nnx.Dict(
             a=nnx.Sequence([nnx.param(10.0), nnx.param(20.0)]),
             b=nnx.param(10.0),
             c=7,

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -13,10 +13,10 @@ def collection(collection: str):
 
 class TestJIT:
     def test_jit(self):
-        m = nnx.Map(a=nnx.param(1))
+        m = nnx.Dict(a=nnx.param(1))
 
         @nnx.jit
-        def g(m: nnx.Map):
+        def g(m: nnx.Dict):
             m.a = 2
             return 1.0
 
@@ -26,10 +26,10 @@ class TestJIT:
         assert out == 1.0
 
     def test_jit_stateless(self):
-        m = nnx.Map(a=nnx.param(1))
+        m = nnx.Dict(a=nnx.param(1))
 
         @partial(nnx.jit, stateful=False)
-        def g(m: nnx.Map):
+        def g(m: nnx.Dict):
             m.a = 2
             return 1.0
 
@@ -44,7 +44,7 @@ class TestGrad:
         p1 = nnx.param(10.0)
         p2 = nnx.param(20.0)
 
-        m = nnx.Map(
+        m = nnx.Dict(
             a=nnx.Sequence([p1, p2]),
             b=p1,
             c=7,
@@ -52,7 +52,7 @@ class TestGrad:
         )
 
         @nnx.grad
-        def f(m: nnx.Map):
+        def f(m: nnx.Dict):
             # sum all params
             return m["a"][0] + m["a"][1] + m["b"]
 
@@ -76,7 +76,7 @@ class TestGrad:
         assert m["d"] == 5.0
 
     def test_grad_with_multiple_ref_types(self):
-        m = nnx.Map(
+        m = nnx.Dict(
             a=nnx.Sequence([nnx.param(10.0), nnx.var("batch_stats", 20.0)]),
             b=nnx.param(10.0),
             c=7,
@@ -84,7 +84,7 @@ class TestGrad:
         )
 
         @nnx.grad
-        def f(m: nnx.Map):
+        def f(m: nnx.Dict):
             # sum all params
             return m.a[0] + m.a[1] + m.b
 
@@ -105,7 +105,7 @@ class TestGrad:
         assert m.d == 5.0
 
     def test_grad_with_type_predicate(self):
-        m = nnx.Map(
+        m = nnx.Dict(
             a=nnx.Sequence([nnx.param(10.0), nnx.var("batch_stats", 20.0)]),
             b=nnx.param(10.0),
             c=7,
@@ -113,7 +113,7 @@ class TestGrad:
         )
 
         @partial(nnx.grad, wrt="batch_stats")
-        def f(m: nnx.Map):
+        def f(m: nnx.Dict):
             # sum all params
             return m.a[0] + m.a[1] + m.b
 


### PR DESCRIPTION
# Changes
* `Pure` now accepts `State | Tuple[State, ...]`, also `Module.partition` now always return `Pure` instances.
* `Map` was renamed to `Dict`.
* Updated readme.
* Added an initial version of `nnx.scan`.