### PR TITLE
Simplify RngStream and Context

### DIFF
--- a/nnx/__init__.py
+++ b/nnx/__init__.py
@@ -14,7 +14,7 @@ from .containers import (
     var_metadata,
     with_partitioning,
 )
-from .contextlib import Context, RngStream, context
+from .contextlib import Context, context
 from .dataclasses import (
     dataclass,
     field,

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -8,7 +8,7 @@ import nnx
 from nnx.contextlib import _stable_hash
 
 
-class TestRngStream:
+class TestContext:
     def test_hash(self):
         _hash = _stable_hash("hi")
         assert isinstance(_hash, int)
@@ -80,8 +80,6 @@ class TestRngStream:
         ):
             ctx1.make_rng("params")
 
-
-class TestContext:
     def test_partition_merge(self):
         ctx = nnx.context(dropout=0)
 


### PR DESCRIPTION
# Changes

Fixes #10.

* Moves all the logic from `RngStream` to `Context` to avoid indirection. 
* `RngStream` is now a simple `dataclass` with no methods and is no longer a Pytree. 
* `RngStream` is no longer exposed to the user.

