### PR TITLE
Type-based collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ One major difference between the two frameworks is that, by design, NNX Modules 
 
 ### Modules
 
-NNX Modules are normal python classes, they obey regular python semantics such as mutability and reference sharing, including reference cycles. They can contain 2 types of attributes: node attributes and static attributes. Node attributes include NNX `Variable`s (e.g. `nnx.param`), Numpy arrays, JAX arrays, submodules Modules, and other NNX types. All other types are treated as static attributes.
+NNX Modules are normal python classes, they obey regular python semantics such as mutability and reference sharing, including reference cycles. They can contain 2 types of attributes: node attributes and static attributes. Node attributes include NNX `Variable`s (e.g. `nnx.Param`), Numpy arrays, JAX arrays, submodules Modules, and other NNX types. All other types are treated as static attributes.
 
 ```python
 class Foo(nnx.Module):
@@ -209,9 +209,9 @@ y, (state, moduledef) = moduledef.apply(state).submodule(x)
 `apply` can call any nested method or submodule as long as it can be accessed via the `.` or `[]` operators.
 
 ### Partitioning State
-`nnx.var` lets you create `Variable` attributes with `collection` metadata, this metadata can be used to partition the state into multiple substates. `nnx.param` is a special case of `nnx.var` where `collection="params"`. 
+In NNX you can filter based on any node type, most commonly you will want to filter based on `nnx.Variable` subclasses such as `nnx.Param` or `nnx.BatchStat`.
 
-Here are various examples of how you can use the `partition` method along with collection names to partition a module into multiple substates:
+Here are various examples of how you can use the `partition` method to split a module into multiple substates:
 
 ```python
 # partition the module into the state with all the nodes and the moduledef

--- a/examples/00_demo.ipynb
+++ b/examples/00_demo.ipynb
@@ -1,309 +1,298 @@
 {
- "cells": [
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "No GPU/TPU found, falling back to CPU. (Set TF_CPP_MIN_LOG_LEVEL=0 and rerun for more info.)\n"
-     ]
+    "cells": [
+        {
+            "cell_type": "code",
+            "execution_count": 1,
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stderr",
+                    "output_type": "stream",
+                    "text": [
+                        "No GPU/TPU found, falling back to CPU. (Set TF_CPP_MIN_LOG_LEVEL=0 and rerun for more info.)\n"
+                    ]
+                },
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "Linear(\n",
+                        "  din=2,\n",
+                        "  dout=2\n",
+                        ")\n",
+                        "[[0.63114893 1.2928092 ]\n",
+                        " [0.63114893 1.2928092 ]]\n"
+                    ]
+                }
+            ],
+            "source": [
+                "import numpy as np\n",
+                "import nnx\n",
+                "import jax\n",
+                "import jax.numpy as jnp\n",
+                "\n",
+                "class Linear(nnx.Module):\n",
+                "    def __init__(self, din: int, dout: int, *, ctx: nnx.Context):\n",
+                "        # static attributes\n",
+                "        self.din = din\n",
+                "        self.dout = dout\n",
+                "        # variables\n",
+                "        self.w = nnx.Param(jax.random.uniform(ctx.make_rng(\"params\"), (din, dout)))\n",
+                "        self.b = nnx.Param(jnp.zeros((dout,)))\n",
+                "        # other state\n",
+                "        self.jax_array = jnp.array(1)\n",
+                "        self.numpy_array = np.array(1)\n",
+                "\n",
+                "    def __call__(self, x):\n",
+                "        return x @ self.w + self.b\n",
+                "    \n",
+                "linear = Linear(2, 2, ctx=nnx.context(0))\n",
+                "\n",
+                "y = linear(jnp.ones((2, 2)))\n",
+                "\n",
+                "print(linear)\n",
+                "print(y)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 2,
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "State({\n",
+                        "  'b': Param(\n",
+                        "    sharding=None,\n",
+                        "    value=Array([0., 0.], dtype=float32)\n",
+                        "  ),\n",
+                        "  'jax_array': Array(1, dtype=int32, weak_type=True),\n",
+                        "  'numpy_array': array(1),\n",
+                        "  'w': Param(\n",
+                        "    sharding=None,\n",
+                        "    value=Array([[0.31696808, 0.55285215],\n",
+                        "           [0.31418085, 0.7399571 ]], dtype=float32)\n",
+                        "  )\n",
+                        "})\n",
+                        "ModuleDef(\n",
+                        "  type=Linear,\n",
+                        "  index=0,\n",
+                        "  submodules=(),\n",
+                        "  static_fields=(('din', 2), ('dout', 2))\n",
+                        ")\n"
+                    ]
+                }
+            ],
+            "source": [
+                "state, moduledef = linear.partition()\n",
+                "\n",
+                "print(state)\n",
+                "print(moduledef)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 3,
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "Linear(\n",
+                        "  din=2,\n",
+                        "  dout=2,\n",
+                        "  submodule=Linear(...)\n",
+                        ")\n",
+                        "[[0.63114893 1.2928092 ]\n",
+                        " [0.63114893 1.2928092 ]]\n"
+                    ]
+                }
+            ],
+            "source": [
+                "class Linear(nnx.Module):\n",
+                "    def __init__(self, din: int, dout: int, *, ctx: nnx.Context):\n",
+                "        self.din = din\n",
+                "        self.dout = dout\n",
+                "        self.w = nnx.Param(jax.random.uniform(ctx.make_rng(\"params\"), (din, dout)))\n",
+                "        self.b = nnx.Param(jnp.zeros((dout,)))\n",
+                "        # introduce a self-reference\n",
+                "        self.submodule = self\n",
+                "\n",
+                "    def __call__(self, x):\n",
+                "        return x @ self.submodule.w + self.submodule.b\n",
+                "    \n",
+                "linear = Linear(2, 2, ctx=nnx.context(0))\n",
+                "\n",
+                "y = linear(jnp.ones((2, 2)))\n",
+                "\n",
+                "print(linear)\n",
+                "print(y)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 4,
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "State({\n",
+                        "  'b': Param(\n",
+                        "    sharding=None,\n",
+                        "    value=Array([0., 0.], dtype=float32)\n",
+                        "  ),\n",
+                        "  'w': Param(\n",
+                        "    sharding=None,\n",
+                        "    value=Array([[0.31696808, 0.55285215],\n",
+                        "           [0.31418085, 0.7399571 ]], dtype=float32)\n",
+                        "  )\n",
+                        "})\n",
+                        "ModuleDef(\n",
+                        "  type=Linear,\n",
+                        "  index=0,\n",
+                        "  submodules=(\n",
+                        "    ('submodule', 0)\n",
+                        "  ),\n",
+                        "  static_fields=(('din', 2), ('dout', 2))\n",
+                        ")\n"
+                    ]
+                }
+            ],
+            "source": [
+                "state, moduledef = linear.partition()\n",
+                "\n",
+                "print(state)\n",
+                "print(moduledef)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 5,
+            "metadata": {},
+            "outputs": [
+                {
+                    "data": {
+                        "text/plain": [
+                            "True"
+                        ]
+                    },
+                    "execution_count": 5,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source": [
+                "linear2 = moduledef.merge(state)\n",
+                "\n",
+                "linear2.submodule is linear2"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 6,
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "Linear(\n",
+                        "  din=2,\n",
+                        "  dout=2\n",
+                        ")\n",
+                        "[[0.63114893 1.2928092 ]\n",
+                        " [0.63114893 1.2928092 ]]\n"
+                    ]
+                }
+            ],
+            "source": [
+                "\n",
+                "class Linear(nnx.Module):\n",
+                "    def __init__(self, din: int, dout: int, *, ctx: nnx.Context):\n",
+                "        # static attributes\n",
+                "        self.din = din\n",
+                "        self.dout = dout\n",
+                "        # variables\n",
+                "        self.w = nnx.Param(jax.random.uniform(ctx.make_rng(\"params\"), (din, dout)))\n",
+                "        self.b = nnx.Param(jnp.zeros((dout,)))\n",
+                "\n",
+                "    def __call__(self, x):\n",
+                "        y = x @ self.w + self.b\n",
+                "        self.y = nnx.Intermediate(y)\n",
+                "        return y\n",
+                "    \n",
+                "linear = Linear(2, 2, ctx=nnx.context(0))\n",
+                "\n",
+                "y = linear(jnp.ones((2, 2)))\n",
+                "\n",
+                "print(linear)\n",
+                "print(y)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 8,
+            "metadata": {},
+            "outputs": [
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "State({\n",
+                        "  'y': Intermediate(\n",
+                        "    sharding=None,\n",
+                        "    value=Array([[0.63114893, 1.2928092 ],\n",
+                        "           [0.63114893, 1.2928092 ]], dtype=float32)\n",
+                        "  )\n",
+                        "})\n",
+                        "State({\n",
+                        "  'b': Param(\n",
+                        "    sharding=None,\n",
+                        "    value=Array([0., 0.], dtype=float32)\n",
+                        "  ),\n",
+                        "  'w': Param(\n",
+                        "    sharding=None,\n",
+                        "    value=Array([[0.31696808, 0.55285215],\n",
+                        "           [0.31418085, 0.7399571 ]], dtype=float32)\n",
+                        "  )\n",
+                        "})\n"
+                    ]
+                }
+            ],
+            "source": [
+                "intermediates = linear.pop_state(nnx.Intermediate)\n",
+                "state, moduledef = linear.partition()\n",
+                "\n",
+                "print(intermediates)\n",
+                "print(state)"
+            ]
+        }
+    ],
+    "metadata": {
+        "kernelspec": {
+            "display_name": ".venv",
+            "language": "python",
+            "name": "python3"
+        },
+        "language_info": {
+            "codemirror_mode": {
+                "name": "ipython",
+                "version": 3
+            },
+            "file_extension": ".py",
+            "mimetype": "text/x-python",
+            "name": "python",
+            "nbconvert_exporter": "python",
+            "pygments_lexer": "ipython3",
+            "version": "3.9.16"
+        },
+        "orig_nbformat": 4
     },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Linear(\n",
-      "  din=2,\n",
-      "  dout=2\n",
-      ")\n",
-      "[[0.63114893 1.2928092 ]\n",
-      " [0.63114893 1.2928092 ]]\n"
-     ]
-    }
-   ],
-   "source": [
-    "import numpy as np\n",
-    "import nnx\n",
-    "import jax\n",
-    "import jax.numpy as jnp\n",
-    "\n",
-    "class Linear(nnx.Module):\n",
-    "    def __init__(self, din: int, dout: int, *, ctx: nnx.Context):\n",
-    "        # static attributes\n",
-    "        self.din = din\n",
-    "        self.dout = dout\n",
-    "        # variables\n",
-    "        self.w = nnx.param(jax.random.uniform(ctx.make_rng(\"params\"), (din, dout)))\n",
-    "        self.b = nnx.param(jnp.zeros((dout,)))\n",
-    "        # other state\n",
-    "        self.jax_array = jnp.array(1)\n",
-    "        self.numpy_array = np.array(1)\n",
-    "\n",
-    "    def __call__(self, x):\n",
-    "        return x @ self.w + self.b\n",
-    "    \n",
-    "linear = Linear(2, 2, ctx=nnx.context(0))\n",
-    "\n",
-    "y = linear(jnp.ones((2, 2)))\n",
-    "\n",
-    "print(linear)\n",
-    "print(y)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "State({\n",
-      "  'b': Variable(\n",
-      "    value=Array([0., 0.], dtype=float32),\n",
-      "    collection='params',\n",
-      "    sharding=None\n",
-      "  ),\n",
-      "  'jax_array': Array(1, dtype=int32, weak_type=True),\n",
-      "  'numpy_array': array(1),\n",
-      "  'w': Variable(\n",
-      "    value=Array([[0.31696808, 0.55285215],\n",
-      "           [0.31418085, 0.7399571 ]], dtype=float32),\n",
-      "    collection='params',\n",
-      "    sharding=None\n",
-      "  )\n",
-      "})\n",
-      "ModuleDef(\n",
-      "  type=Linear,\n",
-      "  index=0,\n",
-      "  submodules=(),\n",
-      "  static_fields=(('din', 2), ('dout', 2))\n",
-      ")\n"
-     ]
-    }
-   ],
-   "source": [
-    "state, moduledef = linear.partition()\n",
-    "\n",
-    "print(state)\n",
-    "print(moduledef)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Linear(\n",
-      "  din=2,\n",
-      "  dout=2,\n",
-      "  submodule=Linear(...)\n",
-      ")\n",
-      "[[0.63114893 1.2928092 ]\n",
-      " [0.63114893 1.2928092 ]]\n"
-     ]
-    }
-   ],
-   "source": [
-    "class Linear(nnx.Module):\n",
-    "    def __init__(self, din: int, dout: int, *, ctx: nnx.Context):\n",
-    "        self.din = din\n",
-    "        self.dout = dout\n",
-    "        self.w = nnx.param(jax.random.uniform(ctx.make_rng(\"params\"), (din, dout)))\n",
-    "        self.b = nnx.param(jnp.zeros((dout,)))\n",
-    "        # introduce a self-reference\n",
-    "        self.submodule = self\n",
-    "\n",
-    "    def __call__(self, x):\n",
-    "        return x @ self.submodule.w + self.submodule.b\n",
-    "    \n",
-    "linear = Linear(2, 2, ctx=nnx.context(0))\n",
-    "\n",
-    "y = linear(jnp.ones((2, 2)))\n",
-    "\n",
-    "print(linear)\n",
-    "print(y)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "State({\n",
-      "  'b': Variable(\n",
-      "    value=Array([0., 0.], dtype=float32),\n",
-      "    collection='params',\n",
-      "    sharding=None\n",
-      "  ),\n",
-      "  'w': Variable(\n",
-      "    value=Array([[0.31696808, 0.55285215],\n",
-      "           [0.31418085, 0.7399571 ]], dtype=float32),\n",
-      "    collection='params',\n",
-      "    sharding=None\n",
-      "  ),\n",
-      "  'y': Variable(\n",
-      "    value=Array([[0.63114893, 1.2928092 ],\n",
-      "           [0.63114893, 1.2928092 ]], dtype=float32),\n",
-      "    collection='intermediate',\n",
-      "    sharding=None\n",
-      "  )\n",
-      "})\n",
-      "ModuleDef(\n",
-      "  type=Linear,\n",
-      "  index=0,\n",
-      "  submodules=(),\n",
-      "  static_fields=(('din', 2), ('dout', 2))\n",
-      ")\n"
-     ]
-    }
-   ],
-   "source": [
-    "state, moduledef = linear.partition()\n",
-    "\n",
-    "print(state)\n",
-    "print(moduledef)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "linear2 = moduledef.merge(state)\n",
-    "\n",
-    "linear2.submodule is linear2"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Linear(\n",
-      "  din=2,\n",
-      "  dout=2\n",
-      ")\n",
-      "[[0.63114893 1.2928092 ]\n",
-      " [0.63114893 1.2928092 ]]\n"
-     ]
-    }
-   ],
-   "source": [
-    "\n",
-    "class Linear(nnx.Module):\n",
-    "    def __init__(self, din: int, dout: int, *, ctx: nnx.Context):\n",
-    "        # static attributes\n",
-    "        self.din = din\n",
-    "        self.dout = dout\n",
-    "        # variables\n",
-    "        self.w = nnx.param(jax.random.uniform(ctx.make_rng(\"params\"), (din, dout)))\n",
-    "        self.b = nnx.param(jnp.zeros((dout,)))\n",
-    "\n",
-    "    def __call__(self, x):\n",
-    "        y = x @ self.w + self.b\n",
-    "        self.y = nnx.variable(\"intermediate\", y)\n",
-    "        return y\n",
-    "    \n",
-    "linear = Linear(2, 2, ctx=nnx.context(0))\n",
-    "\n",
-    "y = linear(jnp.ones((2, 2)))\n",
-    "\n",
-    "print(linear)\n",
-    "print(y)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "State({})\n",
-      "State({\n",
-      "  'b': Node(\n",
-      "    value=Array([0., 0.], dtype=float32),\n",
-      "    collection='params',\n",
-      "    sharding=None\n",
-      "  ),\n",
-      "  'w': Node(\n",
-      "    value=Array([[0.31696808, 0.55285215],\n",
-      "           [0.31418085, 0.7399571 ]], dtype=float32),\n",
-      "    collection='params',\n",
-      "    sharding=None\n",
-      "  )\n",
-      "})\n"
-     ]
-    }
-   ],
-   "source": [
-    "intermediates = linear.pop_state(\"intermediate\")\n",
-    "state, moduledef = linear.partition()\n",
-    "\n",
-    "print(intermediates)\n",
-    "print(state)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": ".venv",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.17"
-  },
-  "orig_nbformat": 4
- },
- "nbformat": 4,
- "nbformat_minor": 2
+    "nbformat": 4,
+    "nbformat_minor": 2
 }

--- a/examples/01_functional_api.py
+++ b/examples/01_functional_api.py
@@ -18,8 +18,8 @@ def dataset(batch_size):
 
 class Linear(nnx.Module):
     def __init__(self, din: int, dout: int, *, ctx: nnx.Context):
-        self.w = nnx.param(jax.random.uniform(ctx.make_rng("params"), (din, dout)))
-        self.b = nnx.param(jnp.zeros((dout,)))
+        self.w = nnx.Param(jax.random.uniform(ctx.make_rng("params"), (din, dout)))
+        self.b = nnx.Param(jnp.zeros((dout,)))
 
     def __call__(self, x):
         return x @ self.w + self.b
@@ -41,7 +41,7 @@ class MLP(nnx.Module):
 
 (params, buffers), modeldef = MLP(
     din=1, dhidden=32, dout=1, ctx=nnx.context(0)
-).partition("params", ...)
+).partition(nnx.Param, ...)
 
 
 @jax.jit

--- a/examples/02_lifted_transforms.py
+++ b/examples/02_lifted_transforms.py
@@ -18,16 +18,20 @@ def dataset(batch_size):
 
 class Linear(nnx.Module):
     def __init__(self, din: int, dout: int, *, ctx: nnx.Context):
-        self.w = nnx.param(jax.random.uniform(ctx.make_rng("params"), (din, dout)))
-        self.b = nnx.param(jnp.zeros((dout,)))
+        self.w = nnx.Param(jax.random.uniform(ctx.make_rng("params"), (din, dout)))
+        self.b = nnx.Param(jnp.zeros((dout,)))
 
     def __call__(self, x):
         return x @ self.w + self.b
 
 
+class Count(nnx.Variable):
+    pass
+
+
 class MLP(nnx.Module):
     def __init__(self, din, dhidden, dout, *, ctx: nnx.Context):
-        self.count = nnx.variable("state", jnp.array(0))
+        self.count = Count(jnp.array(0))
         self.linear1 = Linear(din, dhidden, ctx=ctx)
         self.linear2 = Linear(dhidden, dout, ctx=ctx)
 
@@ -51,10 +55,10 @@ def train_step(model: MLP, batch):
         return jnp.mean((y - y_pred) ** 2)
 
     #                                   |--default--|
-    grad: nnx.State = nnx.grad(loss_fn, wrt="params")(model)
+    grad: nnx.State = nnx.grad(loss_fn, wrt=nnx.Param)(model)
     # sdg update
     model.update_state(
-        jax.tree_map(lambda w, g: w - 0.1 * g, model.filter("params"), grad)
+        jax.tree_map(lambda w, g: w - 0.1 * g, model.filter(nnx.Param), grad)
     )
 
     # no return!!!

--- a/examples/03_train_state.py
+++ b/examples/03_train_state.py
@@ -20,8 +20,8 @@ def dataset(batch_size):
 
 class Linear(nnx.Module):
     def __init__(self, din: int, dout: int, *, ctx: nnx.Context):
-        self.w = nnx.param(jax.random.uniform(ctx.make_rng("params"), (din, dout)))
-        self.b = nnx.param(jnp.zeros((dout,)))
+        self.w = nnx.Param(jax.random.uniform(ctx.make_rng("params"), (din, dout)))
+        self.b = nnx.Param(jnp.zeros((dout,)))
 
     def __call__(self, x):
         return x @ self.w + self.b
@@ -43,7 +43,7 @@ class MLP(nnx.Module):
 
 (params, buffers), moduledef = MLP(
     din=1, dhidden=32, dout=1, ctx=nnx.context(0)
-).partition("params", ...)
+).partition(nnx.Param, ...)
 
 state = nnx.TrainState(
     moduledef,

--- a/examples/06_scan_over_layers.py
+++ b/examples/06_scan_over_layers.py
@@ -46,7 +46,7 @@ class ScanMLP(nnx.Module):
         keys, ctxdef = ctx.partition()
         dropout_key = jax.random.split(keys["dropout"], self.n_layers)
         # partition Module to get params
-        params, moduledef = self.layers.partition("params")
+        params, moduledef = self.layers.partition(nnx.Param)
 
         def scan_fn(
             x: jax.Array, inputs: Tuple[nnx.State, jax.Array]
@@ -58,7 +58,7 @@ class ScanMLP(nnx.Module):
             # forward pass
             x = module(x, ctx=ctx)
             # partition state and return
-            params, _ = module.partition("params")
+            params, _ = module.partition(nnx.Param)
             return x, params
 
         # call scan passing x as the carry, and params + dropout_key as the input

--- a/examples/07_transformer.py
+++ b/examples/07_transformer.py
@@ -157,28 +157,28 @@ class Attention(nnx.Module):
         sharding = cfg.sharding
 
         key = ctx.make_rng("params")
-        self.WQ = nnx.param(
+        self.WQ = nnx.Param(
             dense_init(
                 key, (cfg.embed, cfg.heads, cfg.depth), cfg.param_dtype, 0, (1, 2)
             ),
             P(sharding.embed, sharding.heads, sharding.depth),
         )
         key = ctx.make_rng("params")
-        self.WK = nnx.param(
+        self.WK = nnx.Param(
             dense_init(
                 key, (cfg.embed, cfg.heads, cfg.depth), cfg.param_dtype, 0, (1, 2)
             ),
             P(sharding.embed, sharding.heads, sharding.depth),
         )
         key = ctx.make_rng("params")
-        self.WV = nnx.param(
+        self.WV = nnx.Param(
             dense_init(
                 key, (cfg.embed, cfg.heads, cfg.depth), cfg.param_dtype, 0, (1, 2)
             ),
             P(sharding.embed, sharding.heads, sharding.depth),
         )
         key = ctx.make_rng("params")
-        self.WO = nnx.param(
+        self.WO = nnx.Param(
             dense_init(
                 key, (cfg.heads, cfg.depth, cfg.embed), cfg.param_dtype, (0, 1), 2
             ),
@@ -258,19 +258,19 @@ class Attention(nnx.Module):
 class MLP(nnx.Module):
     def __init__(self, cfg: Config, *, ctx: nnx.Context):
         sharding = cfg.sharding
-        self.Win1 = nnx.param(
+        self.Win1 = nnx.Param(
             dense_init(
                 ctx.make_rng("params"), (cfg.embed, cfg.hidden), cfg.param_dtype, 0, 1
             ),
             P(sharding.embed, sharding.hidden),
         )
-        self.Win2 = nnx.param(
+        self.Win2 = nnx.Param(
             dense_init(
                 ctx.make_rng("params"), (cfg.embed, cfg.hidden), cfg.param_dtype, 0, 1
             ),
             P(sharding.embed, sharding.hidden),
         )
-        self.Wout = nnx.param(
+        self.Wout = nnx.Param(
             dense_init(
                 ctx.make_rng("params"), (cfg.hidden, cfg.embed), cfg.param_dtype, 0, 1
             ),
@@ -291,10 +291,10 @@ class DecoderBlock(nnx.Module):
         sharding = cfg.sharding
         self.attn = Attention(cfg, ctx=ctx)
         self.mlp = MLP(cfg, ctx=ctx)
-        self.scale1 = nnx.param(
+        self.scale1 = nnx.Param(
             jnp.ones((cfg.embed,), cfg.param_dtype), P(sharding.embed)
         )
-        self.scale2 = nnx.param(
+        self.scale2 = nnx.Param(
             jnp.ones((cfg.embed,), cfg.param_dtype), P(sharding.embed)
         )
 
@@ -312,19 +312,19 @@ class DecoderBlock(nnx.Module):
 class Decoder(nnx.Module):
     def __init__(self, cfg: Config, *, ctx: nnx.Context):
         sharding = cfg.sharding
-        self.embed = nnx.param(
+        self.embed = nnx.Param(
             embed_init(
                 ctx.make_rng("params"), (cfg.vocab, cfg.embed), cfg.param_dtype, 1, 0
             ),
             P(sharding.vocab, sharding.embed),
         )
-        self.unembed = nnx.param(
+        self.unembed = nnx.Param(
             dense_init(
                 ctx.make_rng("params"), (cfg.embed, cfg.vocab), jnp.float32, 0, 1
             ),
             P(sharding.embed, sharding.vocab),
         )
-        self.scale1 = nnx.param(
+        self.scale1 = nnx.Param(
             jnp.ones((cfg.embed,), cfg.param_dtype), P(sharding.embed)
         )
 

--- a/examples/09_parameter_surgery.py
+++ b/examples/09_parameter_surgery.py
@@ -32,7 +32,7 @@ model = Classifier(backbone, ctx=nnx.context(42))
 
 # create a filter to select all the parameters that are not part of the
 # backbone, i.e. the classifier parameters
-is_trainable = nnx.All("params", lambda path, node: path.startswith("backbone"))
+is_trainable = nnx.All(nnx.Param, lambda path, node: path.startswith("backbone"))
 
 # partition the parameters into trainable and non-trainable parameters
 (trainable_params, non_trainable), moduledef = model.partition(is_trainable, ...)

--- a/ideas/pure_example.py
+++ b/ideas/pure_example.py
@@ -92,7 +92,7 @@ state = model.create_state(rngs)
 @jax.jit
 def train_step(state: pure.State, key, batch):
     x, y = batch
-    params = state.partition("params")
+    params = state.partition(nnx.Param)
     rngs = pure.Rngs(dropout=key)
 
     def loss(params):
@@ -121,7 +121,7 @@ params_keys = jax.random.split(params_keys, n_layers)
 @partial(jax.vmap, in_axes=0, out_axes=(0, None))
 def create_state(params_key: jax.random.KeyArray):
     state = model.create_state(pure.Rngs(params=params_key))
-    params, batch_stats = state.partition("params", "batch_stats")
+    params, batch_stats = state.partition(nnx.Param, "batch_stats")
     return params, batch_stats
 
 
@@ -147,7 +147,7 @@ def scan_fn(
     x, state = model(state, rngs, x, train=True)
 
     # partition state
-    params, batch_stats = state.partition("params", "batch_stats")
+    params, batch_stats = state.partition(nnx.Param, "batch_stats")
 
     return (x, batch_stats), params
 

--- a/ideas/pure_pytree_example.py
+++ b/ideas/pure_pytree_example.py
@@ -115,7 +115,7 @@ params_keys = jax.random.split(params_keys, n_layers)
 def create_state(params_key: jax.random.KeyArray):
     rngs = pure.Rngs(params=params_key)
     model = MLP(10, 20, 10, rngs=rngs)
-    (params, batch_stats), modeldef = model.partition("params", "batch_stats")
+    (params, batch_stats), modeldef = model.partition(nnx.Param, "batch_stats")
     return params, batch_stats, modeldef
 
 

--- a/nnx/__init__.py
+++ b/nnx/__init__.py
@@ -2,15 +2,15 @@ __version__ = "0.0.0"
 
 
 from .containers import (
+    BatchStat,
+    Cached,
     Container,
     ContainerMetadata,
+    Intermediate,
     Node,
+    Param,
     Static,
     Variable,
-    node,
-    param,
-    static,
-    variable,
     with_metadata,
 )
 from .contextlib import Context, context
@@ -58,7 +58,7 @@ from .nn.normalization import BatchNorm, LayerNorm
 from .nn.stochastic import Dropout
 from .nodes import is_node, register_node_type
 from .partitioning import All, Not, buffers
-from .pytreelib import Pytree, tree_node
+from .pytreelib import Pytree, TreeNode
 from .spmd import (
     PARTITION_NAME,
     get_partition_spec,

--- a/nnx/dataclasses.py
+++ b/nnx/dataclasses.py
@@ -47,7 +47,7 @@ def node_field(
     if "nnx_container_fn" in metadata:
         raise ValueError("'nnx_container_fn' found in metadata")
 
-    metadata["nnx_container_fn"] = lambda value: containers.node(value)
+    metadata["nnx_container_fn"] = lambda value: containers.Node(value)
 
     return field(
         default=default,
@@ -78,7 +78,7 @@ def static_field(
     if "nnx_container_fn" in metadata:
         raise ValueError("'nnx_container_fn' found in metadata")
 
-    metadata["nnx_container_fn"] = lambda value: containers.static(value)
+    metadata["nnx_container_fn"] = lambda value: containers.Static(value)
 
     return field(
         default=default,
@@ -92,7 +92,7 @@ def static_field(
 
 
 def var_field(
-    collection: str,
+    variable_type: tp.Type[containers.Variable[tp.Any]],
     *,
     default: tp.Any = dataclasses.MISSING,
     default_factory: tp.Any = dataclasses.MISSING,
@@ -111,9 +111,7 @@ def var_field(
     if "nnx_container_fn" in metadata:
         raise ValueError("'nnx_container_fn' found in metadata")
 
-    metadata["nnx_container_fn"] = lambda value: containers.variable(
-        collection, value, sharding=sharding
-    )
+    metadata["nnx_container_fn"] = lambda value: variable_type(value, sharding=sharding)
 
     return field(
         default=default,
@@ -137,7 +135,7 @@ def param_field(
     metadata: tp.Optional[tp.Mapping[str, tp.Any]] = None,
 ) -> tp.Any:
     return var_field(
-        "params",
+        containers.Param,
         default=default,
         default_factory=default_factory,
         init=init,

--- a/nnx/helpers.py
+++ b/nnx/helpers.py
@@ -104,10 +104,10 @@ class TrainState(pytreelib.Pytree, tp.Generic[M]):
         **kwargs,
     ):
         self.moduledef = moduledef
-        self.params: State = pytreelib.tree_node(params)
+        self.params: State = pytreelib.TreeNode(params)
         self.tx = tx
-        self.opt_state = pytreelib.tree_node(tx.init(self.params))
-        self.step = pytreelib.tree_node(jnp.asarray(step))
+        self.opt_state = pytreelib.TreeNode(tx.init(self.params))
+        self.step = pytreelib.TreeNode(jnp.asarray(step))
         for name, value in kwargs.items():
             setattr(self, name, value)
 

--- a/nnx/nn/linear.py
+++ b/nnx/nn/linear.py
@@ -88,14 +88,14 @@ class Linear(Module):
         ctx: contextlib.Context,
     ):
         kernel_key = ctx.make_rng("params")
-        self.kernel = nnx.param(
+        self.kernel = nnx.Param(
             kernel_init(kernel_key, (in_features, out_features), param_dtype)
         )
         if use_bias:
             bias_key = ctx.make_rng("params")
-            self.bias = nnx.param(bias_init(bias_key, (out_features,), param_dtype))
+            self.bias = nnx.Param(bias_init(bias_key, (out_features,), param_dtype))
         else:
-            self.bias = nnx.param(None)
+            self.bias = nnx.Param(None)
 
         self.in_features = in_features
         self.out_features = out_features
@@ -206,14 +206,14 @@ class Conv(Module):
             out_features,
         )
         kernel_key = ctx.make_rng("params")
-        self.kernel = nnx.param(kernel_init(kernel_key, kernel_shape, param_dtype))
+        self.kernel = nnx.Param(kernel_init(kernel_key, kernel_shape, param_dtype))
 
         if use_bias:
             bias_shape = (out_features,)
             bias_key = ctx.make_rng("params")
-            self.bias = nnx.param(bias_init(bias_key, bias_shape, param_dtype))
+            self.bias = nnx.Param(bias_init(bias_key, bias_shape, param_dtype))
         else:
-            self.bias = nnx.param(None)
+            self.bias = nnx.Param(None)
 
         self.in_features = in_features
         self.out_features = out_features
@@ -368,7 +368,7 @@ class Embed(Module):
         ] = default_embed_init,
         ctx: contextlib.Context,
     ):
-        self.embedding = nnx.param(
+        self.embedding = nnx.Param(
             embedding_init(
                 ctx.make_rng("params"), (num_embeddings, features), param_dtype
             )

--- a/nnx/nn/normalization.py
+++ b/nnx/nn/normalization.py
@@ -194,20 +194,20 @@ class BatchNorm(Module):
         ctx: contextlib.Context,
     ):
         feature_shape = (num_features,)
-        self.mean = nnx.variable("batch_stats", jnp.zeros(feature_shape, jnp.float32))
-        self.var = nnx.variable("batch_stats", jnp.ones(feature_shape, jnp.float32))
+        self.mean = nnx.BatchStat(jnp.zeros(feature_shape, jnp.float32))
+        self.var = nnx.BatchStat(jnp.ones(feature_shape, jnp.float32))
 
         if use_scale:
             key = ctx.make_rng("params")
-            self.scale = nnx.param(scale_init(key, feature_shape, param_dtype))
+            self.scale = nnx.Param(scale_init(key, feature_shape, param_dtype))
         else:
-            self.scale = nnx.param(None)
+            self.scale = nnx.Param(None)
 
         if use_bias:
             key = ctx.make_rng("params")
-            self.bias = nnx.param(bias_init(key, feature_shape, param_dtype))
+            self.bias = nnx.Param(bias_init(key, feature_shape, param_dtype))
         else:
-            self.bias = nnx.param(None)
+            self.bias = nnx.Param(None)
 
         self.num_features = num_features
         self.use_running_average = use_running_average
@@ -328,15 +328,15 @@ class LayerNorm(Module):
 
         if use_scale:
             key = ctx.make_rng("params")
-            self.scale = nnx.param(scale_init(key, feature_shape, param_dtype))
+            self.scale = nnx.Param(scale_init(key, feature_shape, param_dtype))
         else:
-            self.scale = nnx.param(None)
+            self.scale = nnx.Param(None)
 
         if use_bias:
             key = ctx.make_rng("params")
-            self.bias = nnx.param(bias_init(key, feature_shape, param_dtype))
+            self.bias = nnx.Param(bias_init(key, feature_shape, param_dtype))
         else:
-            self.bias = nnx.param(None)
+            self.bias = nnx.Param(None)
 
         self.num_features = num_features
         self.epsilon = epsilon

--- a/nnx/partitioning.py
+++ b/nnx/partitioning.py
@@ -14,13 +14,13 @@ else:
 
 Path = str
 Predicate = tp.Callable[[Path, tp.Any], bool]
-FilterLiteral = tp.Union[str, type, Predicate, ellipsis, None]
+FilterLiteral = tp.Union[type, Predicate, ellipsis, None]
 Filter = tp.Union[FilterLiteral, tp.Tuple[FilterLiteral, ...]]
 
 
 def to_predicate(filter: Filter) -> Predicate:
     if isinstance(filter, str):
-        return FromCollection(filter)
+        raise TypeError(f"Invalid filter of type '{type(filter).__name__}'")
     elif isinstance(filter, type):
         return OfType(filter)
     elif filter is Ellipsis:
@@ -32,17 +32,7 @@ def to_predicate(filter: Filter) -> Predicate:
     elif isinstance(filter, tp.Tuple):
         return Any(*filter)
     else:
-        raise TypeError(f"Invalid collection filter: {filter}")
-
-
-@dataclasses.dataclass
-class FromCollection:
-    collection: str
-
-    def __call__(self, path: Path, x: tp.Any):
-        if isinstance(x, nnx.Variable):
-            return x.collection == self.collection
-        return False
+        raise TypeError(f"Invalid collection filter: {filter:!r}. ")
 
 
 @dataclasses.dataclass

--- a/nnx/pytreelib.py
+++ b/nnx/pytreelib.py
@@ -20,11 +20,6 @@ class TreeNode(containers.NodeBase[A]):
     pass
 
 
-@partial(containers.check_container, num_arg=0)
-def tree_node(value: A, **metadata: tp.Any) -> A:
-    return TreeNode(value, **metadata)  # type: ignore
-
-
 @contextlib.contextmanager
 def _mutable(obj: P) -> tp.Iterator[None]:
     vars(obj)["_pytree__is_mutable"] = True

--- a/nnx/state.py
+++ b/nnx/state.py
@@ -30,12 +30,6 @@ class State(tp.Mapping[Path, Leaf], reprlib.Representable):
         else:
             self._mapping = dict(sorted(__input, key=lambda x: x[0]))
 
-    def get_collections(self) -> tp.Set[tp.Union[str, None]]:
-        return {
-            value.collection if isinstance(value, Node) else None
-            for value in self._mapping.values()
-        }
-
     def __getitem__(self, __key: Path) -> Leaf:
         return self._mapping[__key]
 

--- a/nnx/transforms.py
+++ b/nnx/transforms.py
@@ -7,7 +7,7 @@ import jax.numpy as jnp
 import jax.stages
 import jax.tree_util as jtu
 
-from nnx import contextlib, partitioning, spmd, tracers
+from nnx import containers, contextlib, partitioning, spmd, tracers
 from nnx.module import CallableProxy, DelayedAccessor, Module, ModuleDef, PureModule
 from nnx.state import State
 
@@ -220,7 +220,7 @@ def grad(
 
 def grad(
     fun: tp.Callable[..., tp.Any],
-    wrt: partitioning.Filter = "params",
+    wrt: partitioning.Filter = containers.Param,
     *,
     stateful: bool = True,
     has_aux: bool = False,

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -7,34 +7,34 @@ import nnx
 
 class TestContainers:
     def test_node_idenpotence(self):
-        x = nnx.node(1)
-        x = nnx.node(x)
+        x = nnx.Node(1)
+        x = nnx.Node(x)
 
         assert isinstance(x, nnx.Node)
 
     def test_variable_idenpotence(self):
-        x = nnx.variable("x", 1)
-        x = nnx.variable("x", x)
+        x = nnx.Variable(1)
+        x = nnx.Variable(x)
 
-        assert isinstance(x, nnx.Node)
-        assert x.collection == "x"
+        assert isinstance(x, nnx.Variable)
+        assert x.value == 1
 
     def test_variable_cannot_change_collection(self):
-        x = nnx.variable("x", 1)
+        x = nnx.Param(1)
 
-        with pytest.raises(ValueError, match="is not equivalent to"):
-            x = nnx.variable("y", x)
+        with pytest.raises(ValueError, match="is not compatible with return type"):
+            x = nnx.BatchStat(x)
 
     def test_container_cannot_change_type(self):
-        x = nnx.variable("x", 1)
+        x = nnx.Variable(1)
 
-        with pytest.raises(ValueError, match="is not equivalent to"):
-            x = nnx.node(x)
+        with pytest.raises(ValueError, match="is not compatible with return type"):
+            x = nnx.Node(x)
 
-        x = nnx.node(2)
+        x = nnx.Node(2)
 
-        with pytest.raises(ValueError, match="is not equivalent to"):
-            x = nnx.variable("x", x)
+        with pytest.raises(ValueError, match="is not compatible with return type"):
+            x = nnx.Variable(x)
 
     def test_static_is_empty(self):
         leaves = jax.tree_util.tree_leaves(nnx.Static(1))

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -7,18 +7,18 @@ import nnx
 
 class TestHelpers:
     def test_train_state(self):
-        m = nnx.Dict(a=nnx.param(1), b=nnx.variable("batch_stats", 2))
+        m = nnx.Dict(a=nnx.Param(1), b=nnx.BatchStat(2))
 
-        (params, batch_stats), moduledef = m.partition("params", "batch_stats")
+        (params, batch_stats), moduledef = m.partition(nnx.Param, nnx.BatchStat)
 
         state = nnx.TrainState(
             moduledef,
             params=params,
             tx=optax.sgd(1.0),
             batch_stats=batch_stats,
-            other=nnx.node(100),
+            other=nnx.Node(100),
             int=200,
-            static=nnx.static(300),
+            static=nnx.Static(300),
         )
 
         leaves = jax.tree_util.tree_leaves(state)
@@ -41,7 +41,7 @@ class TestHelpers:
                 return x
 
         module = Foo(ctx=nnx.context(0))
-        (params, batch_stats), moduledef = module.partition("params", "batch_stats")
+        (params, batch_stats), moduledef = module.partition(nnx.Param, nnx.BatchStat)
 
         state = nnx.TrainState(
             moduledef,

--- a/tests/test_partitioning.py
+++ b/tests/test_partitioning.py
@@ -18,12 +18,12 @@ def has_collection(collection):
 class TestPartitioning:
     def test_partition(self):
         m = nnx.Dict(
-            a=nnx.Sequence([nnx.param(1), nnx.variable("batch_stats", 2)]),
-            b=nnx.param(2),
+            a=nnx.Sequence([nnx.Param(1), nnx.BatchStat(2)]),
+            b=nnx.Param(2),
             c=100,
         )
 
-        (params, rest), moduledef = m.partition("params", ...)
+        (params, rest), moduledef = m.partition(nnx.Param, ...)
 
         assert len(params) == 2
         assert len(rest) == 1
@@ -44,48 +44,48 @@ class TestPartitioning:
 
     def test_complete_partitioning(self):
         m = nnx.Dict(
-            a=nnx.Sequence([nnx.param(1), nnx.param(2), nnx.node(3)]),
-            b=nnx.Dict(c=nnx.param(1), d=nnx.variable("batch_stats", 2)),
+            a=nnx.Sequence([nnx.Param(1), nnx.Param(2), nnx.Node(3)]),
+            b=nnx.Dict(c=nnx.Param(1), d=nnx.BatchStat(2)),
         )
 
         # no error
-        m.partition("params", "batch_stats", nnx.Node)
+        m.partition(nnx.Param, nnx.BatchStat, nnx.Node)
 
     def test_complete_partitioning_plus_ellipsis(self):
         m = nnx.Dict(
-            a=nnx.Sequence([nnx.param(1), nnx.param(2), nnx.node(3)]),
-            b=nnx.Dict(c=nnx.param(1), d=nnx.variable("batch_stats", 2)),
+            a=nnx.Sequence([nnx.Param(1), nnx.Param(2), nnx.Node(3)]),
+            b=nnx.Dict(c=nnx.Param(1), d=nnx.BatchStat(2)),
         )
 
         # no error if additional ... is passed at the end
-        m.partition("params", "batch_stats", nnx.Node, ...)
+        m.partition(nnx.Param, nnx.BatchStat, nnx.Node, ...)
 
     def test_inclomplete_partition_error(self):
         m = nnx.Dict(
-            a=nnx.Sequence([nnx.param(1), nnx.param(2), nnx.node(3)]),
-            b=nnx.Dict(c=nnx.param(1), d=nnx.variable("batch_stats", 2)),
+            a=nnx.Sequence([nnx.Param(1), nnx.Param(2), nnx.Node(3)]),
+            b=nnx.Dict(c=nnx.Param(1), d=nnx.BatchStat(2)),
         )
 
         with pytest.raises(
             ValueError, match="Non-exhaustive filters, got a non-empty remainder"
         ):
-            m.partition("params")
+            m.partition(nnx.Param)
 
     def test_ellipsis_not_last_error(self):
         m = nnx.Dict(
-            a=nnx.Sequence([nnx.param(1), nnx.param(2), nnx.node(3)]),
-            b=nnx.Dict(c=nnx.param(1), d=nnx.variable("batch_stats", 2)),
+            a=nnx.Sequence([nnx.Param(1), nnx.Param(2), nnx.Node(3)]),
+            b=nnx.Dict(c=nnx.Param(1), d=nnx.BatchStat(2)),
         )
 
         with pytest.raises(
             ValueError, match="Ellipsis `...` can only be used as the last filter,"
         ):
-            m.partition(..., "params")
+            m.partition(..., nnx.Param)
 
     def test_update_from(self):
         m = nnx.Dict(
-            a=nnx.Sequence([nnx.param(1), nnx.variable("batch_stats", 3)]),
-            b=nnx.param(2),
+            a=nnx.Sequence([nnx.Param(1), nnx.BatchStat(3)]),
+            b=nnx.Param(2),
             c=100,
         )
 
@@ -101,8 +101,8 @@ class TestPartitioning:
 
     def test_update_from_with_array_leaf(self):
         m = nnx.Dict(
-            a=nnx.Sequence([nnx.param(1), nnx.variable("batch_stats", 3)]),
-            b=nnx.param(2),
+            a=nnx.Sequence([nnx.Param(1), nnx.BatchStat(3)]),
+            b=nnx.Param(2),
             c=jax.numpy.array(100),
         )
 
@@ -118,12 +118,12 @@ class TestPartitioning:
 
     def test_grad_example(self):
         m = nnx.Dict(
-            a=nnx.Sequence([nnx.param(1.0), nnx.variable("batch_stats", -10)]),
-            b=nnx.param(2.0),
+            a=nnx.Sequence([nnx.Param(1.0), nnx.BatchStat(-10)]),
+            b=nnx.Param(2.0),
             c=100,
         )
 
-        params = m.filter("params")
+        params = m.filter(nnx.Param)
 
         def loss(params):
             return sum(2 * p for p in jax.tree_util.tree_leaves(params))
@@ -138,8 +138,8 @@ class TestPartitioning:
 
     def test_get_paritition(self):
         m = nnx.Dict(
-            a=nnx.Sequence([nnx.param(10.0), nnx.param(20.0)]),
-            b=nnx.param(10.0),
+            a=nnx.Sequence([nnx.Param(10.0), nnx.Param(20.0)]),
+            b=nnx.Param(10.0),
             c=7,
             d=5.0,
         )

--- a/tests/test_pytree.py
+++ b/tests/test_pytree.py
@@ -12,7 +12,7 @@ class TestPytree:
         class Foo(nnx.Pytree):
             def __init__(self, y) -> None:
                 self.x = 2
-                self.y = nnx.node(y)
+                self.y = nnx.Node(y)
 
         pytree = Foo(y=3)
 
@@ -72,7 +72,7 @@ class TestPytree:
         class Bar(nnx.Pytree):
             def __init__(self, a, b):
                 self.a = a
-                self.b = nnx.node(b)
+                self.b = nnx.Node(b)
 
         @nnx.dataclass
         class Foo(nnx.Pytree):
@@ -196,7 +196,7 @@ class TestMutablePytree:
         class Foo(nnx.Pytree, mutable=True):
             def __init__(self, y) -> None:
                 self.x = 2
-                self.y = nnx.node(y)
+                self.y = nnx.Node(y)
 
         pytree = Foo(y=3)
 
@@ -218,7 +218,7 @@ class TestMutablePytree:
     def test_no_new_fields_after_init(self):
         class Foo(nnx.Pytree, mutable=True):
             def __init__(self, x):
-                self.x = nnx.node(x)
+                self.x = nnx.Node(x)
 
         foo = Foo(x=1)
         foo.x = 2

--- a/tests/test_spmd.py
+++ b/tests/test_spmd.py
@@ -13,7 +13,7 @@ class TestSPMD:
     def test_init(self):
         class Foo(nnx.Module):
             def __init__(self):
-                self.w = nnx.param(
+                self.w = nnx.Param(
                     nnx.with_logical_partitioning(
                         lambda: jnp.ones((8, 2)),
                         sharding=("row", "col"),
@@ -38,7 +38,7 @@ class TestSPMD:
     def test_get_partition_spec(self):
         class Foo(nnx.Module):
             def __init__(self):
-                self.w = nnx.param(
+                self.w = nnx.Param(
                     nnx.with_logical_partitioning(
                         lambda: jnp.ones((8, 2)),
                         sharding=("row", "col"),


### PR DESCRIPTION
# Changes

Uses subtypes of `Variable` instead of a string `collection` attribute to differentiate between the different collection types.