### PR TITLE
Lifted Transforms refactor

### DIFF
--- a/nnx/__init__.py
+++ b/nnx/__init__.py
@@ -68,4 +68,4 @@ from .spmd import (
     with_logical_partitioning,
 )
 from .state import State
-from .transforms import Remat, Scan, grad, jit, scan
+from .transforms import Remat, Scan, grad, jit, remat, scan

--- a/nnx/__init__.py
+++ b/nnx/__init__.py
@@ -68,4 +68,4 @@ from .spmd import (
     with_logical_partitioning,
 )
 from .state import State
-from .transforms import Remat, Scan, grad, jit, remat, scan
+from .transforms import Remat, Scan, grad, jit

--- a/nnx/__init__.py
+++ b/nnx/__init__.py
@@ -68,4 +68,4 @@ from .spmd import (
     with_logical_partitioning,
 )
 from .state import State
-from .transforms import Remat, Scan, grad, jit
+from .transforms import Remat, Scan, grad, jit, scan

--- a/nnx/transforms.py
+++ b/nnx/transforms.py
@@ -678,12 +678,13 @@ def scan(
     if is_init:
 
         @functools.wraps(f)
-        def init_wrapper(module: M, *args, **kwargs) -> M:
+        def init_wrapper(module: Module, *args, **kwargs):
             def module_constructor(*args, **kwargs):
                 f(module, *args, **kwargs)
                 return module
 
-            return scan_init(options, module_constructor, args, kwargs)
+            lifted_module = scan_init(options, module_constructor, args, kwargs)
+            module.update_state(lifted_module)
 
         wrapper = init_wrapper
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -142,7 +142,7 @@ class TestScan:
                 x = nnx.gelu(x)
                 return x, None
 
-        MLP = nnx.scan(
+        MLP = nnx.Scan(
             Block, variable_axes={nnx.Param: 0}, split_rngs="params", length=5
         )
 
@@ -176,7 +176,7 @@ class TestScan:
                 x = nnx.gelu(x)
                 return x, None
 
-        MLP = nnx.scan(
+        MLP = nnx.Scan(
             Block,
             variable_axes={nnx.Param: 0},
             # variable_carry="batch_stats",
@@ -228,7 +228,7 @@ class TestScan:
 
                 return x, None
 
-        MLP = nnx.scan(
+        MLP = nnx.Scan(
             Block,
             variable_axes={nnx.Param: 0},
             split_rngs=["params"],
@@ -258,7 +258,7 @@ class TestScan:
 
 class TestRemat:
     def test_basic_remat(self):
-        RematLinear = nnx.remat(nnx.Linear)
+        RematLinear = nnx.Remat(nnx.Linear)
 
         module = RematLinear(2, 3, ctx=nnx.context(0))
 
@@ -275,9 +275,9 @@ class TestRemat:
                 x = self.linear(x)
                 return x, None
 
-        RematLinear = nnx.remat(LinearBlock)
+        RematLinear = nnx.Remat(LinearBlock)
 
-        ScanRematLinear = nnx.scan(
+        ScanRematLinear = nnx.Scan(
             RematLinear, variable_axes={nnx.Param: 0}, split_rngs="params", length=5
         )
 


### PR DESCRIPTION
# Changes

* Type-based lifted transforms suchs as `nnx.scan` and `nnx.remat` are now used via `nnx.Scan` and `nnx.Remat`.
* `nnx.scan` and `nnx.remat` are now function transformations that can be used to decorate module methods.